### PR TITLE
Add button color a/c to percentage of jobs passed

### DIFF
--- a/src/app/table/table.component.css
+++ b/src/app/table/table.component.css
@@ -129,8 +129,8 @@ a {
   position: relative;
   display: inline-block;
 }
-/* 
-  .btn {
+
+  /* .btn {
     padding: 0px;
   } */
 

--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -43,7 +43,7 @@
         <!-- AWS Buttons -->
         <td class="text-center ">
 
-          <span [ngClass]='buttonStatusClass(post.status)' data-toggle="tooltip" data-html="true" data-placement="bottom"
+          <span style ="margin-right:6px" [ngClass]='buttonStatusClass(post.status)' data-toggle="tooltip" data-html="true" data-placement="bottom"
             title="{{tooltipStatus(i, restItems.dashboard['pipelines'][0])}}">
             <i [ngClass]='iconClass(post.status)' style="font-size:12px"></i>
             <span class="passingText">
@@ -53,10 +53,10 @@
           </span>
           <div class="btn-group btn-group-justified">
             <!-- Buttons Linking to Litmus -->
-            <button type="button" [ngClass]='buttonClass(post.status)' (click)="clickit(post.web_url);">
+            <button type="button" [ngClass]='buttonClass(post)' (click)="clickit(post.web_url);">
               <i class="fab fa-gitlab" style="font-size:12px"></i> GITLAB
             </button>
-            <button type="button" [ngClass]='buttonClass(post.status)' (click)="clickit(post.log_link);">
+            <button type="button" [ngClass]='buttonClass(post)' (click)="clickit(post.log_link);">
               <i class="fa fa-eye" style="font-size:12px"></i> LOGS
             </button>
           </div>
@@ -67,10 +67,10 @@
         <!-- GCP Buttons -->
         <td>
 
-          <span [ngClass]="buttonStatusClass(gcpStatus(i, restItems.dashboard['pipelines'][1]))"
+          <span style ="margin-right:6px" [ngClass]="buttonStatusClass(gcpStatus(i, restItems.dashboard['pipelines'][1], 'statusbutton'))"
             data-toggle="tooltip" data-html="true" data-placement="bottom" title="{{tooltipStatus(i, restItems.dashboard['pipelines'][1])}}">
             <!--gcpItems[post.length].status-->
-            <i [ngClass]="iconClass(gcpStatus(i, restItems.dashboard['pipelines'][1]))" style="font-size:12px"></i>
+            <i [ngClass]="iconClass(gcpStatus(i, restItems.dashboard['pipelines'][1], 'statusbutton'))" style="font-size:12px"></i>
             <!-- {{gcpStatus(i, restItems.dashboard['pipelines'][1]).toUpperCase() }} -->
             {{passStatus(i, restItems.dashboard['pipelines'][1])}}
         </span>
@@ -86,9 +86,9 @@
 
         <!-- Azure Buttons -->
         <td>
-          <span [ngClass]="buttonStatusClass(azureStatus(i, restItems.dashboard['pipelines'][3]))"
+          <span style ="margin-right:6px" [ngClass]="buttonStatusClass(azureStatus(i, restItems.dashboard['pipelines'][3], 'statusbutton'))"
             data-toggle="tooltip" data-html="true" data-placement="bottom" title="{{tooltipStatus(i, restItems.dashboard['pipelines'][3])}}">
-            <i [ngClass]="iconClass(azureStatus(i, restItems.dashboard['pipelines'][3]))" style="font-size:12px"></i>
+            <i [ngClass]="iconClass(azureStatus(i, restItems.dashboard['pipelines'][3], 'statusbutton'))" style="font-size:12px"></i>
             <!-- {{azureStatus(i, restItems.dashboard['pipelines'][3]).toUpperCase() }} -->
             {{passStatus(i, restItems.dashboard['pipelines'][3])}}
         </span>

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -38,13 +38,38 @@ export class TableComponent implements OnInit {
     return this.http.get<any[]>(this.restItemsUrl).pipe(map(data => data));
   }
   // Button Class Name a/c to the status
-  buttonClass(status) {
-    if (status == "success") return "btn btn-sqr btn-outline-success";
-    else if (status == "pending") return "btn btn-sqr btn-outline-warning";
-    else if (status == "canceled") return "btn btn-sqr btn-outline-secondary";
-    else if (status == "failed") return "btn btn-sqr btn-outline-danger";
-    else if (status == "running") return "btn btn-sqr btn-outline-primary";
-    else if (status == "N/A") return "btn btn-sqr btn-outline-cancel disabled";
+  buttonClass(post) {
+    if (post.status == "success") return "btn btn-sqr btn-outline-success";
+    else if (post.status == "pending") return "btn btn-sqr btn-outline-warning";
+    else if (post.status == "canceled") return "btn btn-sqr btn-outline-secondary";
+    else if (post.status == "failed") {
+      var status = this.pipelinePercentage(post)
+      if (status > 50) {
+        return "btn btn-sqr btn-outline-success";
+      } else {
+        return "btn btn-sqr btn-outline-danger";
+      }
+    }
+    else if (post.status == "running") return "btn btn-sqr btn-outline-primary";
+    else if (post.status == "N/A") return "btn btn-sqr btn-outline-cancel disabled";
+  }
+
+  pipelinePercentage(post) {
+    var totaljobs = 0;
+    var passedjobs = 0;
+    try {
+      for (var job in post.jobs) {
+        var allpost = post.jobs[job];
+        totaljobs += 1;
+        if (allpost.status === "success") {
+          passedjobs += 1;
+        }
+      }
+    } catch {
+      return "N/A";
+    }
+    var totalPercentage = (passedjobs/totaljobs) * 100;
+    return totalPercentage;
   }
 
   // Fa Icon a/c to the status
@@ -54,7 +79,6 @@ export class TableComponent implements OnInit {
     else if (status == "pending") return "fa fa-clock-o";
     else if (status == "failed") return "fa fa-exclamation-triangle";
     else if (status == "running") return "fa fa-circle-o-notch fa-spin";
-    console.log("test");
   }
   buttonStatusClass(status) {
     if (status == "success") return "btn btn-txt btn-outline-success disabled";
@@ -93,10 +117,14 @@ export class TableComponent implements OnInit {
 
   // GCP Pipeline
   // This function extracts the Run status in GCP pipeline using current index
-  gcpStatus(index, gcpItems) {
+  gcpStatus(index, gcpItems, type) {
     try {
       if (gcpItems[index].status) {
-        return gcpItems[index].status;
+        if (type == 'statusbutton') {
+          return gcpItems[index].status;
+        } else {
+          return gcpItems[index];
+        }
       } else {
         return "N/A";
       }
@@ -134,10 +162,14 @@ export class TableComponent implements OnInit {
 
   // azure Pipeline
   // This function extracts the Run status in azure pipeline using current index
-  azureStatus(index, azureItems) {
+  azureStatus(index, azureItems, type) {
     try {
       if (azureItems[index].status) {
-        return azureItems[index].status;
+        if (type == 'statusbutton') {
+          return azureItems[index].status;
+        } else {
+          return azureItems[index];
+        }
       } else {
         return "N/A";
       }


### PR DESCRIPTION
- Status button color changes according to the percentage of `jobs` in `gitlab` passed

**For Example**

  - if pipeline failed and total jobs passed is above 50% then button color will be green otherwise red

![image](https://user-images.githubusercontent.com/28861964/45954652-3596c480-c02b-11e8-9095-081baa6b82a5.png)


Signed-off-by: Chandan Kumar <chandan.kr404@gmail.com>