### PR TITLE
[fix]: Remove typo, bug fix in workload dashboard

### DIFF
--- a/src/app/workload-dashboard/workload-dashboard.component.html
+++ b/src/app/workload-dashboard/workload-dashboard.component.html
@@ -41,7 +41,7 @@
                           <div class="d-flex justify-content-between w-100">
                             <div>
                               <img src="/assets/images/workloads-logos/mongo.svg" alt="" style="height:50px;width:50px">
-                              <p class="mb-2">Mongo</p>
+                              <p class="mb-2">MongoDB</p>
                               <p>3 Replicas </p>
                             </div>
                             <div>
@@ -189,7 +189,7 @@
                           </div>
                         </div>
                       </div>
-                    </div> 
+                    </div>
                     <div class="col-md-4 text-center">
                       <div class="mb-5 shadow-sm bg-white rounded">
                         <div class="d-flex bg-light p-3">
@@ -251,7 +251,10 @@
                           </div>
                         </div>
                       </div>
-                    </div>    
+                    </div>
+                  </div>
+                </div>
+              </div>
               <div class="tab-pane fade" id="profile" role="tabpanel" aria-labelledby="profile-tab">
                 <div class="container-fluid">
                   <div class="row">


### PR DESCRIPTION
**What this PR does**:

- Mongo -> Mongodb
- Remove the duplicate element which are comming in cstor tab of workload dashboard

**Why we need it**:

- There was a typo in workload dashboard "mongo"
-  Duplicated element are coming cStor tab of workload dashboard page

Signed-off-by: inyee786 <intakhab.cusat@gmail.com>


![screenshot from 2018-11-02 15-45-13](https://user-images.githubusercontent.com/20504600/47909576-5a961700-deb6-11e8-9966-c289b4ea7e62.png)
![screenshot from 2018-11-02 15-45-17](https://user-images.githubusercontent.com/20504600/47909577-5a961700-deb6-11e8-9c29-437f03411b56.png)
