### PR TITLE
Show gitlab build stage, improve the donuts, Fix sidebar 

### DIFF
--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -16,7 +16,7 @@
                     <!-- <li class="item cursor-pointer"><a routerLink="#"><img src="/assets/images/icons/workloads.svg">Overview</a></li> -->
                     <li>
                         <a href="#Submenujiva" data-toggle="collapse" class="item dropdown-toggle"><img src="/assets/images/icons/overview.svg" >Jiva</a>
-                        <ul class="collapsed list-unstyled cursor-pointer" id="Submenujiva" style="margin-left:34px">
+                        <ul class="collapsed list-unstyled cursor-pointer collapse show" id="Submenujiva" style="margin-left:34px">
                             <li class="item cursor-pointer" routerLink="mongo-jiva" routerLinkActive="active"><a><img src="/assets/images/workloads-logos/mongo.svg" style="height:20px;">MongoDB</a></li>
                             <li class="item cursor-pointer" routerLink="cockroachdb-jiva" routerLinkActive="active"><a><img src="/assets/images/workloads-logos/cockroachdb.svg" style="height:20px;">CockroachDB</a></li>
                             <li class="item cursor-pointer" routerLink="percona-jiva" routerLinkActive="active"><a><img src="/assets/images/workloads-logos/percona.svg" style="height:20px;">Percona</a></li>
@@ -28,7 +28,7 @@
                     </li>
                     <li class="border-bottom">
                         <a href="#Submenucstor " data-toggle="collapse" class="dropdown-toggle"><img src="/assets/images/icons/overview.svg" >cStor</a>
-                        <ul class="collapsed list-unstyled cursor-pointer " id="Submenucstor" style="margin-left:34px">
+                        <ul class="collapsed list-unstyled cursor-pointer collapse show" id="Submenucstor" style="margin-left:34px">
                                 <li class="item cursor-pointer" routerLink="mongo-cstor" routerLinkActive="active"><a><img src="/assets/images/workloads-logos/mongo.svg" style="height:20px;">MongoDB</a></li>
                             <li class="item cursor-pointer" routerLink="percona-cstor" routerLinkActive="active"><a><img src="/assets/images/workloads-logos/percona.svg" style="height:20px;">Percona</a></li>
                             <li class="item cursor-pointer" routerLink="prometheus-cstor" routerLinkActive="active"><a><img src="/assets/images/workloads-logos/prometheus.svg" style="height:20px;">Prometheus</a></li>

--- a/src/app/table/table.component.html
+++ b/src/app/table/table.component.html
@@ -13,7 +13,8 @@
           <a class="nav-link active" href="#profile" role="tab" data-toggle="tab">
             <h3 style="color:white">BRANCH</h3>
             <h4>Master</h4>
-            <h3 *ngIf="undefined !== restItems" style="color:white">Builds in last one week: {{ masterBuildsCount(restItems.dashboard.build) }}</h3>
+            <h3 *ngIf="undefined !== restItems" style="color:white">Builds in last one week: {{
+              masterBuildsCount(restItems.dashboard.build) }}</h3>
           </a>
         </li>
         <li style="pointer-events:none;" class="nav-item">
@@ -24,210 +25,288 @@
           </a>
         </li>
         <li style="pointer-events:none; cursor:pointer;" class="nav-item">
-        <a class="nav-link" href="#references" role="tab" data-toggle="tab">
-          <!-- <h3>BRANCH</h3> -->
-          <!-- <h4>v0.7.1</h4> -->
-          <!-- <h3>Commit in last one week: _</h3> -->
-        </a>
+          <a class="nav-link" href="#references" role="tab" data-toggle="tab">
+            <!-- <h3>BRANCH</h3> -->
+            <!-- <h4>v0.7.1</h4> -->
+            <!-- <h3>Commit in last one week: _</h3> -->
+          </a>
         </li>
       </ul>
-        <!-- Tab panes -->
-        <div class="table container tab-content">
-          <div role="tabpanel" class="tab-pane active" id="profile">
-            <table id=data style="min-width:800px;overflow-x:auto"  class="table table-borderless">
-              <thead>
-                <tr class="text-center">
-                  <th>Trigger</th>
-                  <th>Build</th>
-                  <th style="text-align:center">E2E Pipelines</th>
-                </tr>
-                <tr class="text-center">
-                    <td></td>
-                    <td></td>
-                    <td style="justify-content: center" class="d-flex text-center;">
-                      <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/gke.svg"><p style="font-size: 13px;">GKE</p></span>
-                      <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/aks.svg"><p style="font-size: 13px;">AKS</p></span>
-                      <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/eks.svg"><p style="font-size: 13px;">EKS</p></span>
-                      <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/packet.svg"><p style="font-size: 13px;">PACKET</p></span>
-                      <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/gcp.svg"><p style="font-size: 13px;">GCP</p></span>
-                      <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/aws.svg"><p style="font-size: 13px;">AWS</p></span>
-                    </td>
-                  </tr>
-              </thead>
-              <tbody *ngIf="undefined !== restItems">
-                <tr [ngClass]="{'row_color': i==rowCount()}" class="text-center" *ngFor="let post of restItems.dashboard['pipelines'][0]; let i = index" [attr.data-index]="i">
-                  <td>
-                    <a style="cursor:pointer; color:#5C93E8" (click)="clickit(commitUrl(i,restItems.dashboard['build']))">{{ getCommitName(i,restItems.dashboard['build']) }}/{{ getCommit(i,restItems.dashboard['build']) |  slice:0:8 }}</a>
-                    <p style="font-size: 12px;">commit: {{ updated(i,restItems.dashboard['build']) }} ago</p>
-                  </td>
-                  <td>
-                    <button placement="bottom" ngbTooltip="{{buildTooltip(i, restItems.dashboard['build'])}}" (click)="clickit(buildWeburl(i, restItems.dashboard['build']));" [ngClass]="buttonStatusClass(buildStatus(i, restItems.dashboard['build']))">
-                      <i style="font-size:13px" [ngClass]="iconClass(buildStatus(i, restItems.dashboard['build']))"></i>
-                      <a style="margin-left:5px; font-size:15px">{{buildStatus(i, restItems.dashboard['build'])}}</a>
-                    </button>
-                  </td>
-                  <td>
-                    <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][0]) }}" [ngClass]="{'highlight': (status == 1 && i==rowCount())}" (click)="detailPannel('GKE', i, restItems.dashboard);" style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
-                      <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
-                        <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                        <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000" stroke-width="8" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
-                        <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400" stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'gke')" stroke-dashoffset="22.5"></circle>
-                      </svg>
-                    </span>
-                    <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][1]) }}" [ngClass]="{'highlight': (status == 2 && i==rowCount())}" (click)="detailPannel('AKS', i, restItems.dashboard);" style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
-                      <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
-                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000" stroke-width="8" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
-                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400" stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'aks')" stroke-dashoffset="22.5"></circle>
-                      </svg>
-                    </span>
-                    <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][2]) }}" [ngClass]="{'highlight': (status == 3 && i==rowCount())}" (click)="detailPannel('EKS', i, restItems.dashboard);" style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
-                      <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
-                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000" stroke-width="8" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
-                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400" stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'eks')" stroke-dashoffset="22.5"></circle>
-                      </svg>
-                    </span>
-                    <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][3]) }}" [ngClass]="{'highlight': (status == 4 && i==rowCount())}" (click)="detailPannel('Packet', i, restItems.dashboard)" style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
-                      <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
-                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000" stroke-width="8" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
-                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400" stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'packet')" stroke-dashoffset="22.5"></circle>
-                      </svg>
-                    </span>
-                    <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][4]) }}" [ngClass]="{'highlight': (status == 5 && i==rowCount())}" (click)="detailPannel('GCP', i, restItems.dashboard);" style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
-                      <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
-                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000" stroke-width="8" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
-                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400" stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'gcp')" stroke-dashoffset="22.5"></circle>
-                      </svg>
-                    </span>
-                    <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][5]) }}" [ngClass]="{'highlight': (status == 6 && i==rowCount())}" (click)="detailPannel('AWS', i, restItems.dashboard);" style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
-                      <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
-                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
-                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000" stroke-width="8" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
-                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400" stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'aws')" stroke-dashoffset="22.5"></circle>
-                    </svg>
-                      </span>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <div role="tabpanel" class="tab-pane fade" id="buzz">bbb</div>
-          <!-- <div role="tabpanel" class="tab-pane fade" id="references">ccc</div> -->
-        </div>
-    </div>
-  </div>
-<!-- table pannel End -->
-
-
-<!-- Detail pannel start -->
-  <div class="col-sm-4 px-0">
-    <div class="detail container border">
-        <div class="text-center">
-        <img src="/assets/images/cloud/{{ image }}">
-        <h5>{{ name }}</h5>
-        <h6>Kubernetes 1.10.0</h6>
-          <button id="btn1" style="margin-right:4px; margin-top:20px;" type="button" class="btn btn-outline-custom"><span class="statusbutton gitlabButton">GITLAB STAGES</span></button>
-          <button (click)="clickit(log_url)" style="margin-left:4px; margin-top:20px;" type="button" class="btn btn-outline-custom"><span class="statusbutton litmusButton">E2E LOGS</span></button>
-        </div>
-
-        <div style="display: none;" class="divClass">
-          <hr>
-          <table class="mx-4 table table-borderless">
+      <!-- Tab panes -->
+      <div class="table container tab-content">
+        <div role="tabpanel" class="tab-pane active" id="profile">
+          <table id=data style="min-width:800px;overflow-x:auto" class="table table-borderless">
             <thead>
-              <tr style="border-bottom: none">
-                <th style="padding: 0px;"><p style="font-size:16px; text-align: left; text-decoration: underline; padding-bottom:10px;">GITLAB STAGES</p></th>
-                <th style="padding: 0px;"><p style="font-size:16px; text-align: left; text-decoration: underline; padding-bottom:10px;">STATUS</p></th>
+              <tr class="text-center">
+                <th>Trigger</th>
+                <th>Build</th>
+                <th style="text-align:center">E2E Pipelines</th>
+              </tr>
+              <tr class="text-center">
+                <td></td>
+                <td></td>
+                <td style="justify-content: center" class="d-flex text-center;">
+                  <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/gke.svg">
+                    <p style="font-size: 13px;">GKE</p>
+                  </span>
+                  <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/aks.svg">
+                    <p style="font-size: 13px;">AKS</p>
+                  </span>
+                  <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/eks.svg">
+                    <p style="font-size: 13px;">EKS</p>
+                  </span>
+                  <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/packet.svg">
+                    <p style="font-size: 13px;">PACKET</p>
+                  </span>
+                  <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/gcp.svg">
+                    <p style="font-size: 13px;">GCP</p>
+                  </span>
+                  <span style="pointer-events: none;" class="mx-4"><img style="padding:2px;" height="26px;" src="/assets/images/cloud/aws.svg">
+                    <p style="font-size: 13px;">AWS</p>
+                  </span>
+                </td>
               </tr>
             </thead>
-            <tbody>
-              <tr style="border-bottom: none">
-                <td style="padding: 0px;"><h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">CLUSTER SETUP</h6></td>
-                <td style="padding: 0px; pointer-events: none;"><i style="font-size:15px; margin-right:8px;" [ngClass]='gitlabStageClass(clusterSetupStatus)'></i><span style="font-size:13px;" [ngClass]='gitlabStageTextClass(providerInfraSetup)'>{{ clusterSetupStatus }}</span></td>
-              </tr>
-              <tr style="border-bottom: none">
-                <td style="padding: 0px;"><h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">PROVIDER INFRA SETUP</h6></td>
-                <td style="padding: 0px; pointer-events: none;"><i style="font-size:15px; margin-right:8px;" [ngClass]='gitlabStageClass(providerInfraSetup)'></i><span style="font-size:13px;" [ngClass]='gitlabStageTextClass(providerInfraSetup)'>{{ providerInfraSetup }}</span></td>
-              </tr>
-              <tr style="border-bottom: none">
-                <td style="padding: 0px;"><h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">STATEFUL APP DEPLOY</h6></td>
-                <td style="padding: 0px; pointer-events: none;"><i style="font-size:15px; margin-right:8px;" [ngClass]='gitlabStageClass(statefulAppDeploy)'></i><span style="font-size:13px;" [ngClass]='gitlabStageTextClass(statefulAppDeploy)'>{{ statefulAppDeploy }}</span></td>
-              </tr>
-              <tr style="border-bottom: none">
-                <td style="padding: 0px;"><h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">APP FUNCTION TEST</h6></td>
-                <td style="padding: 0px; pointer-events: none;"><i style="font-size:15px; margin-right:8px;" [ngClass]='gitlabStageClass(appFunctionTest)'></i><span style="font-size:13px;" [ngClass]='gitlabStageTextClass(appFunctionTest)'>{{ appFunctionTest }}</span></td>
-              </tr>
-              <tr style="border-bottom: none">
-                <td style="padding: 0px;"><h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">APP CHAOS TEST</h6></td>
-                <td style="padding: 0px; pointer-events: none;"><i style="font-size:15px; margin-right:8px;" [ngClass]='gitlabStageClass(appChaosTest)'></i><span style="font-size:13px;" [ngClass]='gitlabStageTextClass(appChaosTest)'>{{ appChaosTest }}</span></td>
-              </tr>
-              <tr style="border-bottom: none">
-                <td style="padding: 0px;"><h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">CLUSTER CLEANUP</h6></td>
-                <td style="padding: 0px; pointer-events: none;"><i style="font-size:15px; margin-right:8px;" [ngClass]='gitlabStageClass(clusterCleanup)'></i><span style="font-size:13px;" [ngClass]='gitlabStageTextClass(clusterCleanup)'>{{ clusterCleanup }}</span></td>
+            <tbody *ngIf="undefined !== restItems">
+              <tr [ngClass]="{'row_color': i==rowCount()}" class="text-center" *ngFor="let post of restItems.dashboard['pipelines'][0]; let i = index"
+                [attr.data-index]="i">
+                <td>
+                  <a style="cursor:pointer; color:#5C93E8" (click)="clickit(commitUrl(i,restItems.dashboard['build']))">{{
+                    getCommitName(i,restItems.dashboard['build']) }}/{{ getCommit(i,restItems.dashboard['build']) |
+                    slice:0:8 }}</a>
+                  <p style="font-size: 12px;">commit: {{ updated(i,restItems.dashboard['build']) }} ago</p>
+                </td>
+                <td>
+                  <button placement="bottom" ngbTooltip="{{buildTooltip(i, restItems.dashboard['build'])}}" (click)="clickit(buildWeburl(i, restItems.dashboard['build']));"
+                    [ngClass]="buttonStatusClass(buildStatus(i, restItems.dashboard['build']))">
+                    <i style="font-size:13px" [ngClass]="iconClass(buildStatus(i, restItems.dashboard['build']))"></i>
+                    <a style="margin-left:5px; font-size:15px">{{buildStatus(i, restItems.dashboard['build'])}}</a>
+                  </button>
+                </td>
+                <td>
+                  <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][0]) }}"
+                    [ngClass]="{'highlight': (status == 1 && i==rowCount())}" (click)="detailPannel('GKE', i, restItems.dashboard);"
+                    style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
+                    <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
+                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
+                        stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
+                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
+                        stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'gke')"
+                        stroke-dashoffset="22.5"></circle>
+                    </svg>
+                  </span>
+                  <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][1]) }}"
+                    [ngClass]="{'highlight': (status == 2 && i==rowCount())}" (click)="detailPannel('AKS', i, restItems.dashboard);"
+                    style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
+                    <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
+                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
+                        stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
+                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
+                        stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'aks')"
+                        stroke-dashoffset="22.5"></circle>
+                    </svg>
+                  </span>
+                  <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][2]) }}"
+                    [ngClass]="{'highlight': (status == 3 && i==rowCount())}" (click)="detailPannel('EKS', i, restItems.dashboard);"
+                    style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
+                    <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
+                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
+                        stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
+                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
+                        stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'eks')"
+                        stroke-dashoffset="22.5"></circle>
+                    </svg>
+                  </span>
+                  <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][3]) }}"
+                    [ngClass]="{'highlight': (status == 4 && i==rowCount())}" (click)="detailPannel('Packet', i, restItems.dashboard)"
+                    style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
+                    <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
+                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
+                        stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
+                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
+                        stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'packet')"
+                        stroke-dashoffset="22.5"></circle>
+                    </svg>
+                  </span>
+                  <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][4]) }}"
+                    [ngClass]="{'highlight': (status == 5 && i==rowCount())}" (click)="detailPannel('GCP', i, restItems.dashboard);"
+                    style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
+                    <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
+                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
+                        stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
+                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
+                        stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'gcp')"
+                        stroke-dashoffset="22.5"></circle>
+                    </svg>
+                  </span>
+                  <span placement="bottom" ngbTooltip="{{ pipelineTooltip(i, restItems.dashboard['pipelines'][5]) }}"
+                    [ngClass]="{'highlight': (status == 6 && i==rowCount())}" (click)="detailPannel('AWS', i, restItems.dashboard);"
+                    style="cursor:pointer; padding-bottom:10px;margin-left:31.9px; margin-right:31.9px;">
+                    <svg width="20" height="20" viewBox="0 0 42 42" class="donut">
+                      <circle class="donut-hole" cx="21" cy="21" r="15.91549430918954" fill="#fff"></circle>
+                      <circle class="donut-ring" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#ff0000"
+                        stroke-width="6" stroke-dasharray="95 5" stroke-dashoffset="22.5"></circle>
+                      <circle class="donut-segment" cx="21" cy="21" r="15.91549430918954" fill="transparent" stroke="#009400"
+                        stroke-width="8" [attr.stroke-dasharray]="getJobPercentFromPipeline(i, restItems.dashboard, 'aws')"
+                        stroke-dashoffset="22.5"></circle>
+                    </svg>
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>
         </div>
-        
+        <div role="tabpanel" class="tab-pane fade" id="buzz">bbb</div>
+        <!-- <div role="tabpanel" class="tab-pane fade" id="references">ccc</div> -->
+      </div>
+    </div>
+  </div>
+  <!-- table pannel End -->
+
+
+  <!-- Detail pannel start -->
+  <div class="col-sm-4 px-0">
+    <div class="detail container border">
+      <div class="text-center">
+        <img src="/assets/images/cloud/{{ image }}">
+        <h5>{{ name }}</h5>
+        <h6>Kubernetes 1.10.0</h6>
+        <button id="btn1" style="margin-right:4px; margin-top:20px;" type="button" class="btn btn-outline-custom"><span
+            class="statusbutton gitlabButton">GITLAB STAGES</span></button>
+        <button (click)="clickit(log_url)" style="margin-left:4px; margin-top:20px;" type="button" class="btn btn-outline-custom"><span
+            class="statusbutton litmusButton">E2E LOGS</span></button>
+      </div>
+
+      <div style="display: none;" class="divClass">
         <hr>
-        <div class="row">
-          <div class="col-sm-4">
-            <div style="padding-top:30px;">
-                <div class="star-ratings-css">
-                  <div style="padding-left:8px;" class="star-ratings-css-top" [style.width]=rating><span>★</span><span>★</span><span>★</span><span>★</span><span>★</span></div>
-                  <div style="padding-left:8px;" class="star-ratings-css-bottom"><span>★</span><span>★</span><span>★</span><span>★</span><span>★</span></div>
-                  <p style="font-size:13px; padding-top:8px;">SCORE</p>
-                </div>
+        <table class="px-3 table table-borderless">
+          <thead>
+            <tr style="border-bottom: none">
+              <th style="padding: 0px;">
+                <p style="font-size:16px; text-align: left; text-decoration: underline; padding-bottom:10px;">GITLAB
+                  STAGES</p>
+              </th>
+              <th style="padding: 0px;">
+                <p style="font-size:16px; text-align: center; text-decoration: underline; padding-bottom:10px;width:90%">STATUS</p>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr style="border-bottom: none">
+              <td style="padding: 0px;">
+                <h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">CLUSTER SETUP</h6>
+              </td>
+              <td class="gitlab_stage_build_status" style="padding: 0px; pointer-events: none;"><span class="gitlab_stage_primary"
+                  [ngClass]='gitlabStageBuildClass(clusterSetupStatus)'>{{ clusterSetupStatus }}</span></td>
+            </tr>
+            <tr style="border-bottom: none">
+              <td style="padding: 0px;">
+                <h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">PROVIDER INFRA SETUP</h6>
+              </td>
+              <td class="gitlab_stage_build_status" style="padding: 0px; pointer-events: none;"><span class="gitlab_stage_primary"
+                  [ngClass]='gitlabStageBuildClass(providerInfraSetup)'>{{ providerInfraSetup }}</span></td>
+            </tr>
+            <tr style="border-bottom: none">
+              <td style="padding: 0px;">
+                <h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">STATEFUL APP DEPLOY</h6>
+              </td>
+              <td class="gitlab_stage_build_status" style="padding: 0px; pointer-events: none;"><span class="gitlab_stage_primary"
+                  [ngClass]='gitlabStageBuildClass(statefulAppDeploy)'>{{ statefulAppDeploy }}</span></td>
+            </tr>
+            <tr style="border-bottom: none">
+              <td style="padding: 0px;">
+                <h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">APP FUNCTION TEST</h6>
+              </td>
+              <td class="gitlab_stage_build_status" style="padding: 0px; pointer-events: none;"><span class="gitlab_stage_primary"
+                  [ngClass]='gitlabStageBuildClass(appFunctionTest)'>{{ appFunctionTest }}</span></td>
+            </tr>
+            <tr style="border-bottom: none">
+              <td style="padding: 0px;">
+                <h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">APP CHAOS TEST</h6>
+              </td>
+              <td class="gitlab_stage_build_status" style="padding: 0px; pointer-events: none;"><span class="gitlab_stage_primary"
+                  [ngClass]='gitlabStageBuildClass(appChaosTest)'>{{ appChaosTest }}</span></td>
+            </tr>
+            <tr style="border-bottom: none">
+              <td style="padding: 0px;">
+                <h6 (click)="clickit(gitlabPipelineUrl)" class="gitlab_stages">CLUSTER CLEANUP</h6>
+              </td>
+              <td class="gitlab_stage_build_status" style="padding: 0px; pointer-events: none;"><span class="gitlab_stage_primary"
+                  [ngClass]='gitlabStageBuildClass(clusterCleanup)'>{{ clusterCleanup }}</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <hr>
+      <div class="row">
+        <div class="col-sm-12">
+          <div style="">
+            <div class="star-ratings-css">
+              <div style="padding-left:8px;" class="star-ratings-css-top" [style.width]=rating><span>★</span><span>★</span><span>★</span><span>★</span><span>★</span></div>
+              <div style="padding-left:8px;" class="star-ratings-css-bottom"><span>★</span><span>★</span><span>★</span><span>★</span><span>★</span></div>
             </div>
+            <p style="font-size:13px; padding-top:8px;">RATING</p>
           </div>
-          <div class="col-sm-4">
+        </div>
+        <div class="col-sm-12 d-flex" style="padding-top:10px;">
+          <div class="w-25">
             <h5 style="color:black;font-size:15px;">{{ totalJobs }}</h5>
             <h6 style="font-size:13px;">TOTAL</h6>
+          </div>
+          <div class="w-25">
+            <h5 style="color:blue;font-size:15px;">{{ executedJobs }}</h5>
+            <h6 style="font-size:13px;">EXECUTED</h6>
+          </div>
+          <div class="w-25">
             <h5 style="color:green;font-size:15px;">{{ passedJobs }}</h5>
             <h6 style="font-size:13px;">PASSED</h6>
           </div>
-          <div class="col-sm-4">
-            <h5 style="color:blue;font-size:15px;">{{ executedJobs }}</h5>
-            <h6 style="font-size:13px;">EXECUTED</h6>
+          <div class="w-25">
             <h5 style="color:red;font-size:15px;">{{ failedJobs }}</h5>
             <h6 style="font-size:13px;">FAILED</h6>
           </div>
-          </div>
-          <hr>
-          <div class="row">
-            <div class="col-sm-4">
-              <h6><img height=55px; src="/assets/images/icons/pull-request.svg"></h6>
-              <h6><a href="{{ pullRequest }}" target="_blank">Pull Request</a></h6>
-            </div>
-            <div class="col-sm-8">
-              <!-- <h6>jiva/#1975 @username</h6> -->
-              <h6 style="margin-top:10px;">{{ commitUser }}</h6>
-              <h6 style="font-size:14px; height:50px; overflow-y:auto">{{ commitMessage }}</h6>
-            </div>
-          </div>
-          <hr>
-          <div class="row">
-              <div class="col-sm-4 text-center">
-                  <a style=" cursor: pointer; color: #007bff" target="_blank" href="https://github.com/openebs/e2e-infrastructure/blob/master/baseline/baseline">Baseline Images</a>
-                <!-- <p style="margin-top:5px;" >Container images used to run this pipeline</p> -->
-              </div>
-              <div class="col-sm-8 text-center">
-                  <p>Container images used to run this pipeline</p>
-                <!-- <a style="cursor:pointer; color: #007bff" (click)=clickit(litmus)>Litmus tests</a>
-                <p style="margin-top:5px;">Litmus tests run in this pipeline</p> -->
-              </div>
-            </div>
+        </div>
       </div>
-      <!-- <br> -->
-      <!-- <div class="detail">
+      <hr>
+      <div class="row">
+        <div class="col-sm-4">
+          <h6><img height=55px; src="/assets/images/icons/pull-request.svg"></h6>
+          <h6><a href="{{ pullRequest }}" target="_blank">Pull Request</a></h6>
+        </div>
+        <div class="col-sm-8">
+          <!-- <h6>jiva/#1975 @username</h6> -->
+          <h6 style="margin-top:10px;">{{ commitUser }}</h6>
+          <h6 style="font-size:14px; height:50px; overflow-y:auto">{{ commitMessage }}</h6>
+        </div>
+      </div>
+      <hr>
+      <div class="row">
+        <div class="col-sm-4 text-center">
+          <a style=" cursor: pointer; color: #007bff" target="_blank" href="https://github.com/openebs/e2e-infrastructure/blob/master/baseline/baseline">Baseline
+            Images</a>
+          <!-- <p style="margin-top:5px;" >Container images used to run this pipeline</p> -->
+        </div>
+        <div class="col-sm-8 text-center">
+          <p>Container images used to run this pipeline</p>
+          <!-- <a style="cursor:pointer; color: #007bff" (click)=clickit(litmus)>Litmus tests</a>
+                <p style="margin-top:5px;">Litmus tests run in this pipeline</p> -->
+        </div>
+      </div>
+    </div>
+    <!-- <br> -->
+    <!-- <div class="detail">
           <div class="card">
               <div class="card-body">
                   <canvas id="chBar"></canvas>
               </div>
           </div>
         </div> -->
-    </div>
-    <!-- detail pannel End -->
   </div>
+  <!-- detail pannel End -->
+</div>

--- a/src/app/table/table.component.scss
+++ b/src/app/table/table.component.scss
@@ -1,243 +1,292 @@
 .body {
-    background-color: white;
-    border-radius: 5px;
+  background-color: white;
+  border-radius: 5px;
 }
 
 .detail {
-    background-color: white;
-    height: 885px;
-    overflow-x: scroll;
-    border-radius: 5px;
+  background-color: white;
+  height: 885px;
+  overflow-x: scroll;
+  border-radius: 5px;
 }
 
 .details {
-    padding: 25px;
+  padding: 25px;
 }
 ul .active {
-    background-image: linear-gradient(#64C2E1, #348FC0);
-    h3 {
-        color: #d3d3d3;
-    }
+  background-image: linear-gradient(#64c2e1, #348fc0);
+  h3 {
+    color: #d3d3d3;
+  }
 }
 h1 {
-    font-size: 1.2em;
-    color: #54576B;
+  font-size: 1.2em;
+  color: #54576b;
 }
 h2 {
-    font-size: 0.9em;
-    color: #949BB3;
+  font-size: 0.9em;
+  color: #949bb3;
 }
 h3 {
-    font-size: 0.8em;
-    text-align: left;
-    padding-left: 20px;
-    color: #949BB3;
+  font-size: 0.8em;
+  text-align: left;
+  padding-left: 20px;
+  color: #949bb3;
 }
 h4 {
-    font-size: 2.6em;
-    text-align: left;
-    padding-left: 20px;
-    color: #3A3D54;
-    font-weight: 10;
+  font-size: 2.6em;
+  text-align: left;
+  padding-left: 20px;
+  color: #3a3d54;
+  font-weight: 10;
 }
 h5 {
-    font-size: 1.2em;
-    color: #54576B;
-    display: block;
-    text-align: center;
+  font-size: 1.2em;
+  color: #54576b;
+  display: block;
+  text-align: center;
 }
 h6 {
-    position:inherit;
-    word-break: normal;
-    font-size: 0.9em;
-    color: #949BB3;
-    text-align: center;
+  position: inherit;
+  word-break: normal;
+  font-size: 0.9em;
+  color: #949bb3;
+  text-align: center;
 }
 
 p {
-    font-size: 15px;
-    color: #949BB3;
-    text-align: center;
-    margin-bottom: 0;
+  font-size: 15px;
+  color: #949bb3;
+  text-align: center;
+  margin-bottom: 0;
 }
 tr {
-    font-size: 0.9em;
-    color: #54576B;
-    border-bottom:1px solid #d3d3d3;
+  font-size: 0.9em;
+  color: #54576b;
+  border-bottom: 1px solid #d3d3d3;
 }
 .btn-txt {
-    padding: 0px;
-    border-width: 0px;
-  }
-  
+  padding: 0px;
+  border-width: 0px;
+}
+
 .btn-txt:hover {
-    background-color: inherit;
-    color: inherit;
+  background-color: inherit;
+  color: inherit;
 }
 
 .avoid-clicks {
-    pointer-events: none;
-  }
+  pointer-events: none;
+}
 
 .table {
-    margin-top:10px;
-    overflow: auto;
-    max-height:630px;
+  margin-top: 10px;
+  overflow: auto;
+  max-height: 630px;
 }
 .button {
-    margin-right: auto;
-    margin-left: auto;
-    display: block;
+  margin-right: auto;
+  margin-left: auto;
+  display: block;
 }
 
 .checked {
-    color: orange;
+  color: orange;
 }
 
 img {
-    padding: 15px;
+  padding: 15px;
 }
 
 // star rating
 .star-ratings-css {
-    unicode-bidi: bidi-override;
-    color: #c5c5c5;
-    font-size: 20px;
-    height: 25px;
-    width: 100px;
-    margin: 0 auto;
-    position: relative;
+  unicode-bidi: bidi-override;
+  color: #c5c5c5;
+  font-size: 20px;
+  height: 25px;
+  width: 100px;
+  margin: 0 auto;
+  position: relative;
+  padding: 0;
+
+  &-top {
+    color: orange;
     padding: 0;
-    
-    &-top {
-      color: orange;
-      padding: 0;
-      position: absolute;
-      z-index: 1;
-      display: block;
-      top: 0;
-      left: 0;
-      overflow: hidden;
-    }
-    &-bottom {
-      padding: 0;
-      display: block;
-      z-index: 0;
-    }
+    position: absolute;
+    z-index: 1;
+    display: block;
+    top: 0;
+    left: 0;
+    overflow: hidden;
   }
+  &-bottom {
+    padding: 0;
+    display: block;
+    z-index: 0;
+  }
+}
 
 .btn-outline-custom:hover {
-    color: #fff;
-    background-image: linear-gradient(#1991EB, #2DA1F8);
-    border-color: #1585D8;
+  color: #fff;
+  background-image: linear-gradient(#1991eb, #2da1f8);
+  border-color: #1585d8;
 }
 
 .btn-outline-custom {
-    color: #354052;
-    background-color: transparent;
-    background-image: none;
-    border-color: #DFE3E9;
+  color: #354052;
+  background-color: transparent;
+  background-image: none;
+  border-color: #dfe3e9;
 }
 
-.btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success:not(:disabled):not(.disabled).active, .show > .btn-outline-success.dropdown-toggle {
-    color: inherit;
-    background-color: white;
-    border-color: #28a745;
+.btn-outline-success:not(:disabled):not(.disabled):active,
+.btn-outline-success:not(:disabled):not(.disabled).active,
+.show > .btn-outline-success.dropdown-toggle {
+  color: inherit;
+  background-color: white;
+  border-color: #28a745;
 }
 
-.btn-outline-danger:not(:disabled):not(.disabled):active, .btn-outline-danger:not(:disabled):not(.disabled).active, .show > .btn-outline-danger.dropdown-toggle {
-    color: inherit;
-    background-color: white;
-    border-color: #dc3545;
+.btn-outline-danger:not(:disabled):not(.disabled):active,
+.btn-outline-danger:not(:disabled):not(.disabled).active,
+.show > .btn-outline-danger.dropdown-toggle {
+  color: inherit;
+  background-color: white;
+  border-color: #dc3545;
 }
 
-.btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active, .show > .btn-outline-secondary.dropdown-toggle {
-    color: inherit;
-    background-color: white;
-    border-color: #6c757d;
+.btn-outline-secondary:not(:disabled):not(.disabled):active,
+.btn-outline-secondary:not(:disabled):not(.disabled).active,
+.show > .btn-outline-secondary.dropdown-toggle {
+  color: inherit;
+  background-color: white;
+  border-color: #6c757d;
 }
 
-.btn-outline-primary:not(:disabled):not(.disabled):active, .btn-outline-primary:not(:disabled):not(.disabled).active, .show > .btn-outline-primary.dropdown-toggle {
+.btn-outline-primary:not(:disabled):not(.disabled):active,
+.btn-outline-primary:not(:disabled):not(.disabled).active,
+.show > .btn-outline-primary.dropdown-toggle {
   color: inherit;
   background-color: white;
   border-color: #007bff;
 }
 
-.btn-outline-warning:not(:disabled):not(.disabled):active, .btn-outline-warning:not(:disabled):not(.disabled).active, .show > .btn-outline-warning.dropdown-toggle {
+.btn-outline-warning:not(:disabled):not(.disabled):active,
+.btn-outline-warning:not(:disabled):not(.disabled).active,
+.show > .btn-outline-warning.dropdown-toggle {
   color: inherit;
   background-color: white;
   border-color: #ffc107;
 }
 
-.btn-outline-dark:not(:disabled):not(.disabled):active, .btn-outline-dark:not(:disabled):not(.disabled).active, .show > .btn-outline-dark.dropdown-toggle {
+.btn-outline-dark:not(:disabled):not(.disabled):active,
+.btn-outline-dark:not(:disabled):not(.disabled).active,
+.show > .btn-outline-dark.dropdown-toggle {
   color: inherit;
   background-color: white;
   border-color: #343a40;
 }
 
 .gitlabButton {
-    padding-left:15px;
-    padding-right:15px; 
-    font-weight: bold; 
-    font-size:15px
+  padding-left: 15px;
+  padding-right: 15px;
+  font-weight: bold;
+  font-size: 15px;
 }
 
 .litmusButton {
-    padding-left:25px; 
-    padding-right:25px; 
-    font-weight: bold; 
-    font-size:15px
+  padding-left: 25px;
+  padding-right: 25px;
+  font-weight: bold;
+  font-size: 15px;
 }
 
 @media only screen and (max-width: 1500px) {
+  .statusbutton {
+    font-size: 13px !important;
+  }
+  @media only screen and (max-width: 1400px) {
     .statusbutton {
-        font-size: 13px !important; 
+      font-size: 11px !important;
+      padding-left: 14px;
+      padding-right: 14px;
     }
-    @media only screen and (max-width: 1400px) {
-        .statusbutton {
-            font-size: 11px !important; 
-            padding-left:14px;
-            padding-right:14px;
-        }
-    }
+  }
 }
 
 .btn-status-warning {
-    color:  #ffb000;
-    background-color: transparent;
-    background-image: none;
-    border-color:  #ffb000;
+  color: #ffb000;
+  background-color: transparent;
+  background-image: none;
+  border-color: #ffb000;
 }
 
 .custom-pointer {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 a:hover {
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .fa {
-    font-size: 17px;
+  font-size: 17px;
 }
 
 .highlight {
-  border-bottom: 5px solid #654CF9;
+  border-bottom: 5px solid #654cf9;
 }
 
 .row_color {
-    // background-color: #F2F4F6;
-    background-color: #ededed;
+  // background-color: #F2F4F6;
+  background-color: #ededed;
 }
 
 .gitlab_stages {
-    color:#354052;
-    text-align: left;
-    font-size:15px;
+  color: #354052;
+  text-align: left;
+  font-size: 15px;
 }
 
 .gitlab_stages:hover {
-    color:#007bff;
-    cursor: pointer;
-    font-weight: bold;
+  color: #007bff;
+  cursor: pointer;
+  font-weight: bold;
 }
+
+.gitlab_stage_build_status {
+    display: flex;
+    justify-content: center;
+    width: 90%;
+}
+.gitlab_stage_primary{
+    border-radius: 24px;
+    padding: 0.5rem 0rem;
+    margin-top: 0.2rem;
+    margin-bottom: 0.2rem;
+    width: 90%;
+    font-size:13px;
+    text-align: center;
+}
+.gitlab_stage_build_success {
+  background-color: rgba(128,174,59,0.55);
+  color: #335500;
+
+}
+.gitlab_stage_build_failed {
+  background-color: rgba(237,123,123,0.55);
+  color: #760606;
+}
+.gitlab_stage_build_running {
+    background: rgba(108,138,255,0.55);
+  color: #0000a1;
+}
+.gitlab_stage_build_skipped {
+  background-color: rgba(201,202,206,0.55);
+  color: #4e5672;
+}
+.gitlab_stage_build_pending {
+  background-color: rgba(232,223,17,0.55);
+  color: #656204;
+}
+

--- a/src/app/table/table.component.ts
+++ b/src/app/table/table.component.ts
@@ -31,7 +31,7 @@ export class TableComponent implements OnInit {
   constructor(private http: HttpClient,private meta:Meta,private titleService: Title ) {
     this.host = window.location.host;
     if ((this.host.toString().indexOf("localhost") + 1) && this.host.toString().indexOf(":")) {
-      this.restItemsUrl = "http://localhost:3000";
+      this.restItemsUrl = "https://staging.openebs.ci/api/";
     } else if (this.host == "openebs.ci") {
         this.restItemsUrl = "https://openebs.ci/api/";
     } else {
@@ -314,39 +314,23 @@ export class TableComponent implements OnInit {
     }
   }
 
-  gitlabStageClass(status) {
-    if (status == "SUCCESS") {
-      return "fa fa-check-circle btn-txt btn-outline-success";
-    }
-    else if (status == "CANCELLED" || status == "SKIPPED" ) {
-      return "fa fa-ban btn-txt btn-outline-secondary";
-    }
-    else if (status == "PENDING") {
-      return "fa fa-clock-o btn-txt btn-outline-secondary";
-    }
-    else if (status == "RUNNING") {
-      return "fa fa-circle-o-notch btn-txt fa-spin btn-outline-primary";
-    }
-    else if (status == "FAILED") {
-      return "fa fa-exclamation-triangle btn-txt btn-outline-danger";
-    }
-  }
 
-  gitlabStageTextClass(status) {
-    if (status == "SUCCESS") {
-      return "btn-txt btn-outline-success";
+
+  gitlabStageBuildClass(status) {
+    if (status === "SUCCESS") {
+      return "gitlab_stage_build_success";
     }
-    else if (status == "CANCELLED" || status == "SKIPPED") {
-      return "btn-outline-secondary";
+    else if (status === "CANCELED" || status === "SKIPPED") {
+      return "gitlab_stage_build_skipped";
     }
-    else if (status == "PENDING") {
-      return "btn-txt btn-outline-secondary";
+    else if (status === "PENDING") {
+      return "gitlab_stage_build_pending";
     }
-    else if (status == "RUNNING") {
-      return "btn-txt fa-spin btn-outline-primary";
+    else if (status === "RUNNING") {
+      return "gitlab_stage_build_running";
     }
-    else if (status == "FAILED") {
-      return "btn-txt btn-outline-danger";
+    else if (status === "FAILED") {
+      return "gitlab_stage_build_failed";
     }
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -83,7 +83,7 @@
 
 </head>
 
-<body style="overflow: hidden; background-color: #EFF2F6; font-family: sans-serif">
+<body style=" background-color: #EFF2F6; font-family: sans-serif">
     <app-root>
         <!-- loading layout replaced by app after startup -->
         <div class="app-loading">


### PR DESCRIPTION
**What this PR does / why we need it**:

- Display the gitlab build status
- Reduce the red stroke in donuts circle
- Make rating and number of job execute in two separate line
- Fix sidebar add "collapse show" class for default opening the dropdown

Signed-off-by: inyee786 <intakhab.cusat@gmail.com>

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
![screenshot from 2018-11-08 16-21-02](https://user-images.githubusercontent.com/20504600/48194205-5bc1bb00-e372-11e8-976a-cacb9f8ad624.png)

