### PR TITLE
Add entrypoint in docker file for change vendor related content

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,13 @@ RUN npm run build -- --output-path=./dist/out --configuration $configuration
 
 # Stage 1, based on Nginx, to have only the compiled app, ready for production with Nginx
 FROM nginx:1.15
+#Copy ci-dashboard-dist
 COPY --from=build-stage /app/dist/out/ /usr/share/nginx/html
+#Copy default nginx configuration
 COPY ./nginx-custom.conf /etc/nginx/conf.d/default.conf
+# copy script file
+COPY run.sh /usr/bin/run.sh
+# Set permission for script file
+RUN chmod +x /usr/bin/run.sh
+# Set entrypoint of image
+ENTRYPOINT ["/usr/bin/run.sh"]

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.8.0",
     "@angular/cli": "~6.2.4",
-    "@angular/compiler-cli": "^6.1.0",
+    "@angular/compiler-cli": "^7.2.7",
     "@angular/language-service": "^6.1.0",
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
@@ -48,7 +48,7 @@
     "codelyzer": "~4.3.0",
     "jasmine-core": "~2.99.1",
     "jasmine-spec-reporter": "~4.2.1",
-    "karma": "~3.0.0",
+    "karma": "^4.0.1",
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~1.1.2",
@@ -56,6 +56,6 @@
     "protractor": "~5.4.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.11.0",
-    "typescript": "~2.9.2"
+    "typescript": "^3.2.4"
   }
 }

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# This file will replace the images and css of mo-vendors if ENV `VENDOR` is set
+if [ -n "$VENDOR" ];then
+    echo "------ copying language file ------"
+    cp -rv /tmp/mo-vendor/workload/default-en.json /usr/share/nginx/html/assets/languages/
+    cp -rv /tmp/mo-vendor/workload/image/. /usr/share/nginx/html/assets/images/
+fi
+# start nginx daemon
+nginx-debug -g "daemon off;"


### PR DESCRIPTION
Signed-off-by: Chandan Kumar <chandan.kumar@mayadata.io>

<!--  Thanks for sending a pull request!  Here are some tips for you -->

**What this PR does / why we need it**:

- This will replace the vendor related content.
- If vendor is pass as env for container it will look for the file need to be replace according to run.sh script and file is available at /tmp/mo-vendor/workload directory

Mounted info of volume
```
          volumeMounts:
          - name: config-data
            mountPath: /tmp/mo-vendor/workload
```
- Increase the package version
**Special notes for your reviewer**:
